### PR TITLE
API to fetch stats for Talus device

### DIFF
--- a/src/api/stat/dto/fetched-stat.dto.ts
+++ b/src/api/stat/dto/fetched-stat.dto.ts
@@ -1,0 +1,28 @@
+import { IsDate, IsNotEmpty, IsNumber, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class FetchedStatDto {
+  @ApiProperty({
+    description: 'Name of the stat',
+    example: 'temperature'
+  })
+  @IsNotEmpty()
+  @IsString()
+  statName: string;
+
+  @ApiProperty({
+    description: 'Value of the stat',
+    example: 23.5
+  })
+  @IsNotEmpty()
+  @IsNumber()
+  value: number;
+
+  @ApiProperty({
+    description: 'Timestamp of the stat in ISO format',
+    example: '2024-07-07T12:34:56.789Z'
+  })
+  @IsNotEmpty()
+  @IsDate()
+  timestamp: Date;
+}

--- a/src/api/stat/dto/get-stats.dto.ts
+++ b/src/api/stat/dto/get-stats.dto.ts
@@ -1,0 +1,22 @@
+import { IsDate, IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+
+export class GetStatsDto {
+  @ApiProperty({
+    example: 'uuiodfj-1234-5678-90ab-cdef12345678',
+    description: 'The ID of the Talus device associated with this stat'
+  })
+  @IsNotEmpty()
+  @IsString()
+  talusId: string;
+
+  @ApiProperty({
+    example: '2025-07-06T14:00:00.000Z',
+    description: 'The initial timestamp to fetch stats from (ISO 8601 format)'
+  })
+  @IsNotEmpty()
+  @Type(() => Date)
+  @IsDate()
+  startTime: Date;
+}

--- a/src/api/stat/stat.controller.ts
+++ b/src/api/stat/stat.controller.ts
@@ -1,0 +1,57 @@
+import { Controller, Body, Get, NotFoundException } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBody } from '@nestjs/swagger';
+import { LogUtil } from 'src/utils/log.util';
+import { StatService } from './stat.service';
+import { TalusService } from '../talus/talus.service';
+import { GetStatsDto } from './dto/get-stats.dto';
+import { FetchedStatDto } from './dto/fetched-stat.dto';
+
+@ApiTags('stat')
+@Controller('stat')
+export class StatController {
+  constructor(
+    private readonly talusService: TalusService,
+    private readonly statService: StatService
+  ) {}
+
+  @Get()
+  @ApiOperation({
+    summary: 'Get the stats for a Talus since a given date'
+  })
+  @ApiBody({ type: GetStatsDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Stats fetched successfully',
+    type: [FetchedStatDto]
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Talus not found'
+  })
+  async fetchStats(@Body() data: GetStatsDto): Promise<FetchedStatDto[]> {
+    const existingTalus = await this.talusService.getTalusById(data.talusId);
+
+    if (!existingTalus) {
+      LogUtil.error(
+        `Talus with ID ${data.talusId} not found. Cannot fetch stats.`
+      );
+      throw new NotFoundException(
+        `Talus with ID ${data.talusId} not found. Cannot fetch stats.`
+      );
+    }
+
+    const stats = await this.statService.getStatsByTalus(
+      data.talusId,
+      data.startTime
+    );
+
+    LogUtil.info(
+      `Fetched ${stats.length} stats for Talus with ID ${data.talusId} since ${data.startTime}.`
+    );
+    return stats.map((stat) => ({
+      statName: stat.statName,
+      value: stat.value,
+      timestamp: stat.timestamp
+    }));
+  }
+}

--- a/src/api/stat/stat.module.ts
+++ b/src/api/stat/stat.module.ts
@@ -2,9 +2,12 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Stat } from 'src/entities/stat.entity';
 import { StatService } from './stat.service';
+import { StatController } from './stat.controller';
+import { TalusModule } from '../talus/talus.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Stat])],
+  imports: [TypeOrmModule.forFeature([Stat]), TalusModule],
+  controllers: [StatController],
   providers: [StatService],
   exports: [StatService]
 })

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -22,7 +22,8 @@ import { UserTalusRelationModule } from './api/user-talus-relation/user-talus-re
         DB_USER: Joi.string().required(),
         DB_PASS: Joi.string().required(),
         DB_NAME: Joi.string().required(),
-        IS_DEV: Joi.boolean().default(false)
+        IS_DEV: Joi.boolean().default(false),
+        VERBOSE: Joi.boolean().default(false)
       }),
       validationOptions: {
         abortEarly: false
@@ -44,7 +45,10 @@ import { UserTalusRelationModule } from './api/user-talus-relation/user-talus-re
           ssl: config.get<boolean>('IS_DEV')
             ? false
             : { rejectUnauthorized: false },
-          logging: config.get<boolean>('IS_DEV') ? ['query', 'error'] : false
+          logging:
+            config.get<boolean>('IS_DEV') && config.get<boolean>('VERBOSE')
+              ? ['query', 'error']
+              : ['error']
         };
       }
     }),


### PR DESCRIPTION
This pull request introduces new functionality for fetching statistics related to Talus devices, along with improvements to configuration logging behavior. The most important changes include the addition of DTOs for handling stat-related data, a new controller for fetching stats, updates to the `StatModule` to integrate the controller and dependencies, and enhancements to conditional logging in the application configuration.

### New functionality for fetching Talus stats:

* [`src/api/stat/dto/fetched-stat.dto.ts`](diffhunk://#diff-47614b5c4ae3eaf7fff4c3a88679fba53b48a1de3b9df541ee09b6a58314b21fR1-R28): Added `FetchedStatDto`, a data transfer object for representing fetched statistics with validation and API documentation support.
* [`src/api/stat/dto/get-stats.dto.ts`](diffhunk://#diff-fda945c17540da31318b886fdfa119851e9e8b7b8cdb71eb9712f06066c0ce8bR1-R22): Added `GetStatsDto`, a data transfer object for specifying parameters when fetching stats, including Talus ID and start time.
* [`src/api/stat/stat.controller.ts`](diffhunk://#diff-882e48a3195e751a8d9c693c432d8c09301e9e7dcf9c8be880db1ffccce5d4caR1-R57): Implemented the `StatController` with a new `fetchStats` endpoint to retrieve statistics for a Talus device since a specified date. Includes validation, error handling, and logging.
* [`src/api/stat/stat.module.ts`](diffhunk://#diff-a981ab3ffc32a4f69ec935a59120cd6b7dce39641fb2793d881a4882be59c5dfR5-R10): Updated the `StatModule` to include the `StatController` and integrate the `TalusModule` for dependency injection.

### Configuration logging improvements:

* [`src/app.module.ts`](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8L25-R26): Added a new environment variable `VERBOSE` to control logging verbosity. Modified the logging configuration to include query logs only when both `IS_DEV` and `VERBOSE` are set to true. [[1]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8L25-R26) [[2]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8L47-R51)