### PR TITLE
Created getTalus API.

### DIFF
--- a/src/api/talus/talus.controller.ts
+++ b/src/api/talus/talus.controller.ts
@@ -3,7 +3,9 @@ import {
   Post,
   Body,
   NotFoundException,
-  ConflictException
+  ConflictException,
+  Get,
+  Query
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBody } from '@nestjs/swagger';
 import { LogUtil } from 'src/utils/log.util';
@@ -23,6 +25,27 @@ export class TalusController {
     private readonly userService: UserService,
     private readonly userTalusRelationService: UserTalusRelationService
   ) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Get Talus device by ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Talus device found',
+    type: RegisterTalusDto
+  })
+  @ApiResponse({ status: 404, description: 'Talus device not found' })
+  async getTalusById(
+    @Query('talusId') talusId: string
+  ): Promise<RegisterTalusDto> {
+    const talus = await this.talusService.getTalusById(talusId);
+
+    if (!talus) {
+      LogUtil.error(`Talus device not found: ${talusId}`);
+      throw new NotFoundException('Talus device not found');
+    }
+
+    return talus;
+  }
 
   @Post()
   @ApiOperation({ summary: 'Pair a Talus device with a user' })


### PR DESCRIPTION
This pull request introduces a new API endpoint to retrieve a Talus device by its ID in the `TalusController`. It includes updates to the imports, the controller class, and the addition of a new method `getTalusById`.

### Changes related to the new API endpoint:

* **Added imports for `Get` and `Query` decorators**: Updated the `import` statement in `src/api/talus/talus.controller.ts` to include `Get` and `Query` from `@nestjs/common`.
* **Added `getTalusById` method**: Introduced a new method in the `TalusController` to fetch a Talus device by its ID. This method uses the `@Get` decorator and includes API documentation annotations (`@ApiOperation`, `@ApiResponse`). It handles the case where the device is not found by logging an error and throwing a `NotFoundException`.