### PR TITLE
Change delete talus response to 204.

### DIFF
--- a/src/api/talus/talus.controller.ts
+++ b/src/api/talus/talus.controller.ts
@@ -7,7 +7,8 @@ import {
   Get,
   Query,
   Delete,
-  Put
+  Put,
+  HttpCode
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBody } from '@nestjs/swagger';
 import { LogUtil } from 'src/utils/log.util';
@@ -109,6 +110,7 @@ export class TalusController {
   }
 
   @Delete()
+  @HttpCode(204)
   @ApiOperation({ summary: 'Delete a Talus device by ID' })
   @ApiResponse({
     status: 204,


### PR DESCRIPTION
This pull request introduces a minor update to the `TalusController` in the `src/api/talus/talus.controller.ts` file. The changes include adding an explicit HTTP status code for the `@Delete` endpoint and updating the imports to support this functionality.

### Changes to `TalusController`:

* Added the `HttpCode` decorator to the `@Delete` endpoint to explicitly set the response status code to 204 (No Content). (`[src/api/talus/talus.controller.tsR113](diffhunk://#diff-0a693788459d1d8428a70e833c6634af6be308e82dd1acd85021526d4ee61fc4R113)`)
* Updated the imports to include `HttpCode` from `@nestjs/common`. (`[src/api/talus/talus.controller.tsL10-R11](diffhunk://#diff-0a693788459d1d8428a70e833c6634af6be308e82dd1acd85021526d4ee61fc4L10-R11)`)